### PR TITLE
Only display the actual departure time if it exists

### DIFF
--- a/MMM-UKNationalRail.js
+++ b/MMM-UKNationalRail.js
@@ -175,7 +175,11 @@ Module.register("MMM-UKNationalRail", {
                 //If required, live departure time
                 if (this.config.showActualDeparture) {
                     var actualDepCell = document.createElement("td");
-                    actualDepCell.innerHTML = "(" + myTrain.actualDeparture + ")";
+                    if(myTrain.actualDeparture != null) { // Only display actual time if it exists
+                        actualDepCell.innerHTML = "(" + myTrain.actualDeparture + ")";
+                    } else {
+                        actualDepCell.innerHTML = "&nbsp;";
+                    }
                     actualDepCell.className = "actualTime";
                     row.appendChild(actualDepCell);
                 }


### PR DESCRIPTION
Don't display the actual departure time if it is a `null` value - this can happen if the train has been cancelled, at which point the text `(null)` is displayed. This PR will place a non-breaking space in the table cell instead. 