### PR TITLE
Fix blank header issue

### DIFF
--- a/MMM-UKNationalRail.js
+++ b/MMM-UKNationalRail.js
@@ -56,7 +56,7 @@ Module.register("MMM-UKNationalRail", {
 
     //Define header for module.
     getHeader: function() {
-        return this.config.header;
+        return this.data.header;
     },
 
     // Define start sequence.
@@ -130,10 +130,6 @@ Module.register("MMM-UKNationalRail", {
         // *** Start Building Table
         var table = document.createElement("table");
         table.className = "small";
-
-        if (this.trains.stationName !== null) {
-            this.config.header = this.trains.stationName;
-        }
 
         //With data returned
         if (this.trains.data.length > 0) {


### PR DESCRIPTION
The `config` field no longer contains the `config.header` variable defined in the module configuration - this is now located in `data` instead. 

Additionally, remove overwriting of the header if we have a station name returned.